### PR TITLE
update all dependencies to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,19 @@
       "name": "aws-amplify-gen2",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-amplify/ui-react": "^6.1.9",
-        "aws-amplify": "^6.2.0",
-        "next": "13.5.4",
-        "react": "^18",
-        "react-dom": "^18"
+        "@aws-amplify/ui-react": "^6.1.11",
+        "aws-amplify": "^6.3.2",
+        "next": "^14.2.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^1.0.0",
-        "@aws-amplify/backend-cli": "^1.0.1",
-        "@types/node": "^20",
-        "@types/react": "^18",
-        "@types/react-dom": "^18",
-        "typescript": "^5.3.2"
+        "@aws-amplify/backend": "^1.0.2",
+        "@aws-amplify/backend-cli": "^1.0.3",
+        "@types/node": "^20.12.12",
+        "@types/react": "^18.3.2",
+        "@types/react-dom": "^18.3.0",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.29.tgz",
-      "integrity": "sha512-P5ULdwdMfDF0URJvHfgyXTuAWN08jWc8L/YhO3gQxLRVfbrI5D2G+0TFLaPfmdymlj3B4JzzC7i9m8qsoL2Atg==",
+      "version": "7.0.31",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.31.tgz",
+      "integrity": "sha512-DYkupdyFkBpgPWi6Boaud1hF7uEiNn28ETT21KzvTxWOc6qiaGUO6sLz7rZ3b2qvAj+qbTz95m4yd9f//576hA==",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.398.0",
         "@aws-sdk/client-kinesis": "3.398.0",
@@ -288,7 +288,7 @@
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/analytics/node_modules/@smithy/util-utf8": {
@@ -304,22 +304,22 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.0.31",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.31.tgz",
-      "integrity": "sha512-QzYpJfFLAG/C4rRkS2b+wCsVVZP9Ata7zJpooBpIY83I0MxcV9AT2Zw/eD/g5jDOg+QqkGLKjJzLXPyzW9yTHA==",
+      "version": "6.0.33",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.33.tgz",
+      "integrity": "sha512-kKkKG7MWccqgYiiIM8UCtToQFHVoDJ1PKPd/LB1DqudGkr314KGwnVI+x84jUijfBmN/VAsuwMUxzUst4bsHRw==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.1.0",
-        "@aws-amplify/api-rest": "4.0.29",
+        "@aws-amplify/api-graphql": "4.1.2",
+        "@aws-amplify/api-rest": "4.0.31",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.0.tgz",
-      "integrity": "sha512-YBbvWfDKGMaC2/uMJij3F6hqTBzopMlCBAqtOTajR1p3fHqtdNFnxz5GBHOnvNPK+IJr7DUc27HjYgTzbvuLRw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.2.tgz",
+      "integrity": "sha512-942OtuUpjy4ht24qJm9TKFB9ZLmSVGmrIw+5/JcFMLelueZ9n/JhhaIfCKAssfRb5P5050GoA4I6zlHB3hSGFw==",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.29",
-        "@aws-amplify/core": "6.1.0",
+        "@aws-amplify/api-rest": "4.0.31",
+        "@aws-amplify/core": "6.2.1",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
@@ -341,20 +341,20 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.29",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.29.tgz",
-      "integrity": "sha512-3MUU14f21TYlAvPzYVi1Ga3D8BBC7XHKNzb8JrSZ6MP+8qd2xd6dC7Q+vfm9dtj72y7lPrJee4DkZtMu7HapiQ==",
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.31.tgz",
+      "integrity": "sha512-RlQjEL6doN57JYyu1aCeqCgqts8JiGYGz4qbdk+1oBZAL3cvLVyn3mB0Js/BOZ8kepD5gj/txXHtXDxgOHJgfg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.12.0.tgz",
-      "integrity": "sha512-SHafjmo6JoYMVp8hgfhY/b7o0JROcyLd8Sc7YCLPZA0koMDtmsyUta8WCVk9VlsjZuokiBegN4pDDjNEs6GXUA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.12.1.tgz",
+      "integrity": "sha512-2Fj6SEKU6HATYHbDLp1DvR3z/ipFwsUv5T+tjczsRU2NxgjJefYCeoaSHevj4BWcdRf0yPRgbYd9zZd5e+GsRA==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
@@ -373,24 +373,24 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.2.2.tgz",
-      "integrity": "sha512-lx/pZPYaGZrB4UV/FNNeUaEUWVrC2ayJJx/0mnZrOceH5OdGUMp1mdZz0epDaShtGanTcq7JOlVuu/1LC6eI7g==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.3.2.tgz",
+      "integrity": "sha512-IS6wWo16eaQcVeD8KJ5twcELprcQyYZw3N3wFJ2h19XlWf069vzb+M4/fJsDLxKcapaeboZkc9OtrCAe2dCLuw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/auth-construct": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth-construct/-/auth-construct-1.0.0.tgz",
-      "integrity": "sha512-Ub/gCT+blTmP5zqjICV32nPCHjZ5UDAySBjNW5Rc78jiF50h/oT4al6WXZ22Qfe09Ub7sUgbrffnOLBk6bwgbw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth-construct/-/auth-construct-1.1.2.tgz",
+      "integrity": "sha512-bTnEZ2R2Y/B2lesiEPw8/OB6oCqKqMsSxPwgdLaojlPrAkQTjoP2qcM1BD+beULxBG3YqX2ddTA2sVnTICpBRQ==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
@@ -400,19 +400,19 @@
       }
     },
     "node_modules/@aws-amplify/backend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.0.0.tgz",
-      "integrity": "sha512-QKLdTFtXnff4VUHmZBs+XK3xeXe0TZAZkR4Ke2kwWo6engaYahZ3UQO7Ndkt1D/xcq08e4QayGgRB+XGr7B8Wg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.0.2.tgz",
+      "integrity": "sha512-6Ib8glOd+hhnhWXBYx663wQqZRSdtqo5N8RIUg2+F7RyXHTyu1t3ubQIIJB5fz1mmX6ckCacQJJQsV8T7LMjYw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.0.0",
-        "@aws-amplify/backend-data": "^1.0.0",
-        "@aws-amplify/backend-function": "^1.0.0",
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/backend-auth": "^1.0.2",
+        "@aws-amplify/backend-data": "^1.0.1",
+        "@aws-amplify/backend-function": "^1.0.1",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/backend-storage": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.0",
+        "@aws-amplify/backend-storage": "^1.0.1",
+        "@aws-amplify/client-config": "^1.0.2",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
@@ -425,13 +425,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-auth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-auth/-/backend-auth-1.0.0.tgz",
-      "integrity": "sha512-SVisgT7IR7Ixl28EyEBW5KednA41b2lkV7YDcdlShq2Af62gWn3iNnOJAdIlC7NSvr8lmo6pCETjrQy/+lg6zw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-auth/-/backend-auth-1.0.2.tgz",
+      "integrity": "sha512-+UxRsH5ZZhppkyZjhbAuWrVV7L6eHKWEOcF/07cnz8yoZCcilUK2pLbw1tb60WjskV2S45Fi8QmXy4nP+ovJMw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/auth-construct": "^1.1.1",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -440,21 +440,21 @@
       }
     },
     "node_modules/@aws-amplify/backend-cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.0.1.tgz",
-      "integrity": "sha512-cNVM0MioR//pKaexCd7RFFYFLlTx1UEMP+lorE7qdlbo0pJT0v7Vl7nxTFZvOYe/RZVHnVJjHppN1A08e+bVjg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.0.3.tgz",
+      "integrity": "sha512-o2LybnRvUu+fB/SPKohVVSsZ0IKrap0JtAM978xU8SY5CtKXC64xNsOeZB+wmZLVg/89JtK1NYpHbPZGb/1Vzw==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.0",
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.0",
+        "@aws-amplify/client-config": "^1.0.2",
+        "@aws-amplify/deployed-backend-client": "^1.0.1",
         "@aws-amplify/form-generator": "^1.0.0",
-        "@aws-amplify/model-generator": "^1.0.0",
+        "@aws-amplify/model-generator": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/sandbox": "^1.0.0",
+        "@aws-amplify/sandbox": "^1.0.2",
         "@aws-amplify/schema-generator": "^1.0.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -483,13 +483,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.0.0.tgz",
-      "integrity": "sha512-LVeGNYsx0X5GePQZN2wlMFEz/H52kYdFauj27dvQ4sUdDf9k0uu5xAf2LI5U6d4AD+JRPlxBeDw5OjIajfYo+A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.0.1.tgz",
+      "integrity": "sha512-n/zfuG4hGCVL3dWssDpBZOHgaZ/cN3nD1yfWDZdPE/X/loaXar4HOk2AZK/sDRnpfORPrQ6AsBJ5Shz50Sn1Cw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/data-construct": "^1.8.0",
         "@aws-amplify/data-schema-types": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0"
@@ -516,13 +516,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.0.0.tgz",
-      "integrity": "sha512-yjgLWoiWRyrGp4hCd4LNR+2YffV0EuSLQOId6ps3oxEBIpzEKzFW438U3dMYSJ1fNjkgrgIsBld12I1Qmdcgwg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.0.2.tgz",
+      "integrity": "sha512-2qfyI1fgOgI1y8wAsa1cD0GusIbwdzWt5dSyuyTyilM/PUrhuV2+ORUU97HdaivZxLPF82wkRxEULLJe0NLtHg==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/plugin-types": "^1.0.0",
         "execa": "^8.0.1"
       },
@@ -532,21 +532,21 @@
       }
     },
     "node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.0.0.tgz",
-      "integrity": "sha512-NjJY+jUXWF4Eo5ZcwjCAcYvLKHrW2qW4QIMnUG2H/zWhdIAUXwpv9DjIz63ygXj2eGt43u+meFoDzAruWIfSBg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.1.0.tgz",
+      "integrity": "sha512-6qOjtRfSBOzGA2aH+I5oqpoXgMuhEo0clOufgxApid9KyS1ygWKRNBlwXKUh+do2PuM3XEhBHC4x0md5ayFRRQ==",
       "dev": true,
       "peerDependencies": {
         "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/backend-output-storage": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.0.0.tgz",
-      "integrity": "sha512-PuqXI2EmzW/rYrSubCvQ+hVdkzf7rZIsCuFxnZD2i9zDcq99mzJVpiLpinsX7rWZXtnsIFb3M/87CFpVzPREZw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.0.1.tgz",
+      "integrity": "sha512-JjunSz4qJzhVNU/Dsz37gpJVbckY/jR0cEyun9XHvnFYvR41gwyraEP9P1pL+rO3+CFtCqxPMFgp5Ym4at+EyQ==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/platform-core": "^1.0.0"
       },
       "peerDependencies": {
@@ -565,13 +565,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-storage": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-storage/-/backend-storage-1.0.0.tgz",
-      "integrity": "sha512-BayhXFF3YVj1LOoLTRJYco87GXGFIJ+TVjio0lHWKlOWcr5H/+VCgvgSIpJwtqUkMLbmBZfXF6g6tm1fK3dyfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-storage/-/backend-storage-1.0.1.tgz",
+      "integrity": "sha512-j/sw0+T7rDfDobnubokvkNxHiCrdNSS3Rzu6p9m9UEMJaNjKMSEoDeRfG7V6x2YooGHfH9ex2ND7K25cOY5nSA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.0.1",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -592,14 +592,14 @@
       }
     },
     "node_modules/@aws-amplify/client-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.0.0.tgz",
-      "integrity": "sha512-ffeZ8V2Nq59jjT0aGFV8AaIRsVdStccGV6BmOmuD4HSMG8oBLCS0dBPSuVxRgVhXRABqRN+bFMQnHVfnuHZw9Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.0.2.tgz",
+      "integrity": "sha512-qQXObdanFab+3l+vtkGf0hEF0b+vDPe5Y8Vh8L9es2Q6u6lHIKjzeMrP2jjH4q2tGzr5gotiQANl3eCsvjH92Q==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.0",
-        "@aws-amplify/model-generator": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/model-generator": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.0",
         "zod": "^3.22.2"
       },
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-r3ErH/aa5iO7sQjYASduPr2L4YiRX3VBUHjFYlvoCgZTh1RXDjcntBFQ9suQTIsQe4dtk5Z2MqhepqfjUH7zWw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-DRGtPXhhi3Yz1qXPwOlzZAls3mxYF7zBdWr/RrMHtfQzFmnU2TFNgaoe4pMdAOv0ila7uATLYukV8mfwW4HrLA==",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.1.tgz",
-      "integrity": "sha512-u1Vh3AWmPtuYBJ0la2xWhLR1WIS/66nGdYO6enShyIJiN2c9R+RFbjaz8/ol9eWETRdXJ1OcawgKf3E1HiNf5Q==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.3.tgz",
+      "integrity": "sha512-3U+ZiiWr//bV64tOcx+FR+eSE5eTepIva4B4+WnTB5HIZHucaY0UFsTOHfUomf6lOcDuZqG5IXf35xXBjBEw8w==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -774,22 +774,22 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.9.1",
-        "@aws-amplify/graphql-auth-transformer": "3.5.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.5",
+        "@aws-amplify/graphql-api-construct": "1.9.3",
+        "@aws-amplify/graphql-auth-transformer": "3.5.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.7",
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21",
-        "@aws-amplify/graphql-http-transformer": "2.1.21",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.13",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.1",
-        "@aws-amplify/graphql-sql-transformer": "0.3.1",
-        "@aws-amplify/graphql-transformer": "1.5.3",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.22",
+        "@aws-amplify/graphql-http-transformer": "2.1.22",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.15",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.22",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.3",
+        "@aws-amplify/graphql-sql-transformer": "0.3.3",
+        "@aws-amplify/graphql-transformer": "1.5.5",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -840,16 +840,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.1",
+      "version": "3.5.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -862,14 +862,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.5",
+      "version": "2.3.7",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -883,14 +883,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -901,14 +901,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -919,15 +919,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.1",
+      "version": "2.4.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -938,14 +938,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.13",
+      "version": "3.4.15",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
       },
@@ -955,14 +955,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.1",
+      "version": "2.10.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -973,14 +973,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.1",
+      "version": "2.5.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -1012,15 +1012,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.1",
+      "version": "2.7.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1031,15 +1031,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1050,24 +1050,24 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.3",
+      "version": "1.5.5",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.5",
-        "@aws-amplify/graphql-function-transformer": "2.1.21",
-        "@aws-amplify/graphql-http-transformer": "2.1.21",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.13",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.1",
-        "@aws-amplify/graphql-sql-transformer": "0.3.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.7",
+        "@aws-amplify/graphql-function-transformer": "2.1.22",
+        "@aws-amplify/graphql-http-transformer": "2.1.22",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.15",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.22",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.3",
+        "@aws-amplify/graphql-sql-transformer": "0.3.3",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1075,13 +1075,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
@@ -1098,7 +1098,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -1360,11 +1360,11 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.31",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.31.tgz",
-      "integrity": "sha512-JCRU9ZjXjiye7CKO91DHkIkF4SxHN7M0gvcuD4y4p9rIXVerSUbb5Jilbk6zLC8hmDm4E/iyxYBhULgzCMNBMg==",
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.33.tgz",
+      "integrity": "sha512-The1jWh5oQaO7/b284NyYBDF20wqtIyza7qjBf73T3+kTkIviNlSN9hYcFeQWjzmqn/7ScUQGePG6uVWMd3lSQ==",
       "dependencies": {
-        "@aws-amplify/api": "6.0.31",
+        "@aws-amplify/api": "6.0.33",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -1372,16 +1372,16 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/deployed-backend-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.0.0.tgz",
-      "integrity": "sha512-duam2zAzkIHURcfAmQpRf6Wk6PRzEIl4fJ5kv5k4GX9WJvp+S/Xk9lw+AAU5PP4d/XQB0PoxnaXy6yE4f878mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.0.1.tgz",
+      "integrity": "sha512-OHZ0SYTIAfU5lqmLJqR6/qjsX+dXtfkzqDw4Kt6H3Ijfg0MHF7roSH3YtellnJlQ5pV5kCsQA0i9imXp9MOnVw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/platform-core": "^1.0.0",
         "zod": "^3.22.2"
       },
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.1.tgz",
-      "integrity": "sha512-rAlPSPKvPEBSxGLwrMYsi9Ytlxf1JwnDSR3Ph7bg+RrdIKiDPRkzb/MdH4lkgQ6mYr3WJXqI5qYhM02bWKIRtQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.3.tgz",
+      "integrity": "sha512-n/9W8gP3Q+01hA13fcranFxL7ZVDLFdv4T6j97zquma6ZZeJ1pDI0Wlqs0+cevDRAimUaR3nATg42EMCLHVTkQ==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -1461,21 +1461,21 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "3.5.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.5",
+        "@aws-amplify/graphql-auth-transformer": "3.5.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.7",
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21",
-        "@aws-amplify/graphql-http-transformer": "2.1.21",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.13",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.1",
-        "@aws-amplify/graphql-sql-transformer": "0.3.1",
-        "@aws-amplify/graphql-transformer": "1.5.3",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.22",
+        "@aws-amplify/graphql-http-transformer": "2.1.22",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.15",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.22",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.3",
+        "@aws-amplify/graphql-sql-transformer": "0.3.3",
+        "@aws-amplify/graphql-transformer": "1.5.5",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -1526,16 +1526,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.1",
+      "version": "3.5.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -1548,14 +1548,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.5",
+      "version": "2.3.7",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -1569,14 +1569,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1587,14 +1587,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1605,15 +1605,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.1",
+      "version": "2.4.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1624,14 +1624,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.13",
+      "version": "3.4.15",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
       },
@@ -1641,14 +1641,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.1",
+      "version": "2.10.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1659,14 +1659,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21",
+      "version": "2.1.22",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1677,16 +1677,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.1",
+      "version": "2.5.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1",
@@ -1698,15 +1698,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.1",
+      "version": "2.7.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1717,15 +1717,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.30.1"
@@ -1736,24 +1736,24 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.3",
+      "version": "1.5.5",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.5",
-        "@aws-amplify/graphql-function-transformer": "2.1.21",
-        "@aws-amplify/graphql-http-transformer": "2.1.21",
-        "@aws-amplify/graphql-index-transformer": "2.4.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.13",
-        "@aws-amplify/graphql-model-transformer": "2.9.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21",
-        "@aws-amplify/graphql-relational-transformer": "2.5.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.1",
-        "@aws-amplify/graphql-sql-transformer": "0.3.1",
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.7",
+        "@aws-amplify/graphql-function-transformer": "2.1.22",
+        "@aws-amplify/graphql-http-transformer": "2.1.22",
+        "@aws-amplify/graphql-index-transformer": "2.4.3",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.15",
+        "@aws-amplify/graphql-model-transformer": "2.10.1",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.22",
+        "@aws-amplify/graphql-relational-transformer": "2.5.3",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.3",
+        "@aws-amplify/graphql-sql-transformer": "0.3.3",
+        "@aws-amplify/graphql-transformer-core": "2.8.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1761,13 +1761,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.8.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
@@ -1784,7 +1784,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -2122,12 +2122,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.1.tgz",
-      "integrity": "sha512-dY8NhtFZFfjXlM/rODQnj5lg6f7Uj47j7Uh+d/X9mYUMBDygISiEQK8bxKfsLcQW8MIIiAPP8w/BOZOsO35NlQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.2.tgz",
+      "integrity": "sha512-B+PhOqsgczu/bCDYt27/qWeHxBzWDkpxIGjUsx1ingv97jz3j5SsxlRLr2YeNCh019RnTO7gs8Vg/aDE330hCA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.12.0",
+        "@aws-amplify/appsync-modelgen-plugin": "2.12.1",
         "@aws-amplify/graphql-directives": "^1.0.1",
         "@aws-amplify/graphql-docs-generator": "4.2.1",
         "@aws-amplify/graphql-types-generator": "3.6.0",
@@ -2477,13 +2477,13 @@
       }
     },
     "node_modules/@aws-amplify/model-generator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.0.tgz",
-      "integrity": "sha512-qDX4+yUsyGCpUyzlTxl6fmn1bNFSRcabD3X4PijG7Q3beTiUE43wdRTom9gGmTsRnMdqaMZNh67ptdqx4a43qQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.1.tgz",
+      "integrity": "sha512-3pwl6US5OB0Vr0C/y7Cu1Bt5+lnIOi8+SYkH6PswQaOKEE7kWSlxe8lphDg+NDbXI83vgX1GlbNgi0KuofruPA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.0.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.0",
+        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/deployed-backend-client": "^1.0.1",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.0.0",
@@ -2499,15 +2499,15 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.29.tgz",
-      "integrity": "sha512-OZZiFRFgNSZga0EcEE+u10CibWuZl/zaL2JuBg20FMdSrMMORqzjE9ce846tlasROjERBTfJUE0fd/IfSj5aWQ==",
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.31.tgz",
+      "integrity": "sha512-eF1CsyASEgUkULQHfRXPcKQkNbgvXQghKazmoJD5MAqYLiqh2h/q4hszv+oXSPnNedR5xhProDGC9rBUHSpOtA==",
       "dependencies": {
         "lodash": "^4.17.21",
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/platform-core": {
@@ -2536,16 +2536,16 @@
       }
     },
     "node_modules/@aws-amplify/sandbox": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.0.0.tgz",
-      "integrity": "sha512-xhrL18olb4tDuW+OfjLOU7DRC5eecBX2n16DPOOp3eoxVNuDDYhe2QhJIuy1WJCR+uCSJcduuJtoxo4lTMMo6A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.0.2.tgz",
+      "integrity": "sha512-0mCrF/LC0vUV/vd+V66x6IGyg3iIwRD7XI3HgujLkwIgNZ3SficZ7hdRikT/73kcPmBv7kai3l0qjWlOqiYIyQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.0",
+        "@aws-amplify/client-config": "^1.0.2",
+        "@aws-amplify/deployed-backend-client": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.4.0.tgz",
-      "integrity": "sha512-FAbw+CM2nOtU/RJpUP3/hGBNJv6V2IvdbbEb1Xit8AIJm7b8CpaYQN24t86tstF5mlFrJRbo+BETuNo2EVzCEA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.4.2.tgz",
+      "integrity": "sha512-VKpUo9LIAwpJRHHRUUYA4T5ntVBdqNkzj9Gik5pBeYdlIPmvP4A2vt0sgiLV6ICFgNtqyUt4vbugFsGfuxCWng==",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
         "@smithy/md5-js": "2.0.7",
@@ -2583,7 +2583,7 @@
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "^6.1.0"
       }
     },
     "node_modules/@aws-amplify/storage/node_modules/@aws-sdk/types": {
@@ -2630,9 +2630,9 @@
       }
     },
     "node_modules/@aws-amplify/ui": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-6.0.14.tgz",
-      "integrity": "sha512-JilA2h1OtIp/qWz8sydWtW52CAr6C+ydtPB/tzUW8NeBvXG+UBo/dSdQznYLJ9ATwqc+njbiN/C0j/zX5K+NKg==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-6.0.16.tgz",
+      "integrity": "sha512-H1/nZXyWA9uAMpNjUuB8PLhP9AG/5rN1I5ARCuLLZFfPe61fgs02p6lTOVxpwrWeZsL+meFsz3iTgVDQKbmiPw==",
       "dependencies": {
         "csstype": "^3.1.1",
         "lodash": "4.17.21",
@@ -2640,7 +2640,7 @@
         "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.2.0",
+        "aws-amplify": "^6.3.2",
         "xstate": "^4.33.6"
       },
       "peerDependenciesMeta": {
@@ -2650,12 +2650,12 @@
       }
     },
     "node_modules/@aws-amplify/ui-react": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-6.1.9.tgz",
-      "integrity": "sha512-8/nN8aAPGuCafzehv8hT9G9mWmc/D0ZENIzMV8U1Sd4cbT9mUbjjTToMUlnaYesGXmGGTrS6/JiThVMUcOBecA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-6.1.11.tgz",
+      "integrity": "sha512-bIBE8Q68FPPl+c7VfqYiMmEp4AP7gcp0mtVixG67jTY3B9Dl9loCnFohfAaaUjgzL44rAeBoXtzVB1JZOOooaA==",
       "dependencies": {
-        "@aws-amplify/ui": "6.0.14",
-        "@aws-amplify/ui-react-core": "3.0.14",
+        "@aws-amplify/ui": "6.0.16",
+        "@aws-amplify/ui-react-core": "3.0.16",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-dropdown-menu": "1.0.0",
         "@radix-ui/react-slider": "1.0.0",
@@ -2665,7 +2665,7 @@
         "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.2.0",
+        "aws-amplify": "^6.3.2",
         "react": "^16.14.0 || ^17.0 || ^18.0",
         "react-dom": "^16.14.0 || ^17.0 || ^18.0"
       },
@@ -2676,18 +2676,18 @@
       }
     },
     "node_modules/@aws-amplify/ui-react-core": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-3.0.14.tgz",
-      "integrity": "sha512-p3/W94jYP/TZqKx1eKmFSRniPAP9ViVyEScJZkAkApVPg4d3XADJ80k6MqYvXFlx58fSoDqfX3rnc7TK5Q7ekQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-3.0.16.tgz",
+      "integrity": "sha512-+EUR5SkG6VwLWVopfYzW28BKxBe7h3nrRoDtv4BXClN97RXxU4CUJZOhsZHRC65DPLHqB3IwTj9XGOJy/svV6g==",
       "dependencies": {
-        "@aws-amplify/ui": "6.0.14",
+        "@aws-amplify/ui": "6.0.16",
         "@xstate/react": "^3.2.2",
         "lodash": "4.17.21",
         "react-hook-form": "^7.43.5",
         "xstate": "^4.33.6"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.2.0",
+        "aws-amplify": "^6.3.2",
         "react": "^16.14.0 || ^17.0 || ^18.0"
       }
     },
@@ -3025,52 +3025,52 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.569.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.569.0.tgz",
-      "integrity": "sha512-fO/CaiCZdvVCEWeBCa2EvefLveyFf/Cl3AT28vdpGh19ER9qqs4K63V2twgOGA7BKaVl/cX9zHz0tHoO4Fb83Q==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.577.0.tgz",
+      "integrity": "sha512-3+8moknnDrPtialJEKEYsC2ufNFuB8Bd8ehwZ2ZYP7+rGILV6ArgmPYOQjWsCIRMPBIx5E3fhaQhub5xf4leyg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.569.0",
-        "@aws-sdk/client-sts": "3.569.0",
-        "@aws-sdk/core": "3.567.0",
-        "@aws-sdk/credential-provider-node": "3.569.0",
-        "@aws-sdk/middleware-host-header": "3.567.0",
-        "@aws-sdk/middleware-logger": "3.568.0",
-        "@aws-sdk/middleware-recursion-detection": "3.567.0",
-        "@aws-sdk/middleware-user-agent": "3.567.0",
-        "@aws-sdk/region-config-resolver": "3.567.0",
-        "@aws-sdk/types": "3.567.0",
-        "@aws-sdk/util-endpoints": "3.567.0",
-        "@aws-sdk/util-user-agent-browser": "3.567.0",
-        "@aws-sdk/util-user-agent-node": "3.568.0",
-        "@smithy/config-resolver": "^2.2.0",
-        "@smithy/core": "^1.4.2",
-        "@smithy/fetch-http-handler": "^2.5.0",
-        "@smithy/hash-node": "^2.2.0",
-        "@smithy/invalid-dependency": "^2.2.0",
-        "@smithy/middleware-content-length": "^2.2.0",
-        "@smithy/middleware-endpoint": "^2.5.1",
-        "@smithy/middleware-retry": "^2.3.1",
-        "@smithy/middleware-serde": "^2.3.0",
-        "@smithy/middleware-stack": "^2.2.0",
-        "@smithy/node-config-provider": "^2.3.0",
-        "@smithy/node-http-handler": "^2.5.0",
-        "@smithy/protocol-http": "^3.3.0",
-        "@smithy/smithy-client": "^2.5.1",
-        "@smithy/types": "^2.12.0",
-        "@smithy/url-parser": "^2.2.0",
-        "@smithy/util-base64": "^2.3.0",
-        "@smithy/util-body-length-browser": "^2.2.0",
-        "@smithy/util-body-length-node": "^2.3.0",
-        "@smithy/util-defaults-mode-browser": "^2.2.1",
-        "@smithy/util-defaults-mode-node": "^2.3.1",
-        "@smithy/util-endpoints": "^1.2.0",
-        "@smithy/util-middleware": "^2.2.0",
-        "@smithy/util-retry": "^2.2.0",
-        "@smithy/util-utf8": "^2.3.0",
-        "@smithy/util-waiter": "^2.2.0",
+        "@aws-sdk/client-sso-oidc": "3.577.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.0.0",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3078,56 +3078,2138 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.569.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.569.0.tgz",
-      "integrity": "sha512-cD1HcdJNpUZgrATWCAQs2amQKI69pG+jF4b5ySq9KJkVi6gv2PWsD6QGDG8H12lMWaIKYlOpKbpnYTpcuvqUcg==",
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.577.0.tgz",
+      "integrity": "sha512-BwujdXrydlk6UEyPmewm5GqG4nkQ6OVyRhS/SyZP/6UKSFv2/sf391Cmz0hN0itUTH1rR4XeLln8XCOtarkrzg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.569.0",
-        "@aws-sdk/client-sts": "3.569.0",
-        "@aws-sdk/core": "3.567.0",
-        "@aws-sdk/credential-provider-node": "3.569.0",
-        "@aws-sdk/middleware-host-header": "3.567.0",
-        "@aws-sdk/middleware-logger": "3.568.0",
-        "@aws-sdk/middleware-recursion-detection": "3.567.0",
-        "@aws-sdk/middleware-user-agent": "3.567.0",
-        "@aws-sdk/region-config-resolver": "3.567.0",
-        "@aws-sdk/types": "3.567.0",
-        "@aws-sdk/util-endpoints": "3.567.0",
-        "@aws-sdk/util-user-agent-browser": "3.567.0",
-        "@aws-sdk/util-user-agent-node": "3.568.0",
-        "@smithy/config-resolver": "^2.2.0",
-        "@smithy/core": "^1.4.2",
-        "@smithy/fetch-http-handler": "^2.5.0",
-        "@smithy/hash-node": "^2.2.0",
-        "@smithy/invalid-dependency": "^2.2.0",
-        "@smithy/middleware-content-length": "^2.2.0",
-        "@smithy/middleware-endpoint": "^2.5.1",
-        "@smithy/middleware-retry": "^2.3.1",
-        "@smithy/middleware-serde": "^2.3.0",
-        "@smithy/middleware-stack": "^2.2.0",
-        "@smithy/node-config-provider": "^2.3.0",
-        "@smithy/node-http-handler": "^2.5.0",
-        "@smithy/protocol-http": "^3.3.0",
-        "@smithy/smithy-client": "^2.5.1",
-        "@smithy/types": "^2.12.0",
-        "@smithy/url-parser": "^2.2.0",
-        "@smithy/util-base64": "^2.3.0",
-        "@smithy/util-body-length-browser": "^2.2.0",
-        "@smithy/util-body-length-node": "^2.3.0",
-        "@smithy/util-defaults-mode-browser": "^2.2.1",
-        "@smithy/util-defaults-mode-node": "^2.3.1",
-        "@smithy/util-endpoints": "^1.2.0",
-        "@smithy/util-middleware": "^2.2.0",
-        "@smithy/util-retry": "^2.2.0",
-        "@smithy/util-utf8": "^2.3.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.577.0.tgz",
+      "integrity": "sha512-njmKSPDWueWWYVFpFcZ2P3fI6/pdQVDa0FgCyYZhOnJLgEHZIcBBg1AsnkVWacBuLopp9XVt2m+7hO6ugY1/1g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sts": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.577.0.tgz",
+      "integrity": "sha512-509Kklimva1XVlhGbpTpeX3kOP6ORpm44twJxDHpa9TURbmoaxj7veWlnLCbDorxDTrbsDghvYZshvcLsojVpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/core": {
+      "version": "3.576.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.576.0.tgz",
+      "integrity": "sha512-KDvDlbeipSTIf+ffKtTg1m419TK7s9mZSWC8bvuZ9qx6/sjQFOXIKOVqyuli6DnfxGbvRcwoRuY99OcCH1N/0w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^2.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/signature-v4": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
+      "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.577.0.tgz",
+      "integrity": "sha512-n++yhCp67b9+ZRGEdY1jhamB5E/O+QsIDOPSuRmdaSGMCOd82oUEKPgIVEU1bkqxDsBxgiEWuvtfhK6sNiDS0A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.577.0.tgz",
+      "integrity": "sha512-q7lHPtv6BjRvChUE3m0tIaEZKxPTaZ1B3lKxGYsFl3VLAu5N8yGCUKwuA1izf4ucT+LyKscVGqK6VDZx1ev3nw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.577.0.tgz",
+      "integrity": "sha512-epZ1HOMsrXBNczc0HQpv0VMjqAEpc09DUA7Rg3gUJfn8umhML7A7bXnUyqPA+S54q397UYg1leQKdSn23OiwQQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.577.0",
+        "@aws-sdk/credential-provider-ini": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
+      "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.577.0.tgz",
+      "integrity": "sha512-iVm5SQvS7EgZTJsRaqUOmDQpBQPPPat42SCbWFvFQOLrl8qewq8OP94hFS5w2mP62zngeYzqhJnDel79HXbxew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.577.0",
+        "@aws-sdk/token-providers": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
+      "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
+      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
+      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
+      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
+      "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
+      "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/token-providers": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
+      "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
+      "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
+      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
+      "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/config-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
+      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/hash-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
+      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
+      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/node-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/node-http-handler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/property-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/protocol-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
+      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/signature-v4": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/smithy-client": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
+      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/url-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
+      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
+      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
+      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-endpoints": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
+      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-middleware": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
+      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-retry": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
+      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
+      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-waiter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
+      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.577.0.tgz",
+      "integrity": "sha512-y1fHORHoufrzj2GcnY52g4ykemFpT0Hu9e9kYa6yR0weQ0WalcG7WcnMNasXMcjr9fDjNze7ZCTuWJSI+HwkTQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.577.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.577.0.tgz",
+      "integrity": "sha512-BwujdXrydlk6UEyPmewm5GqG4nkQ6OVyRhS/SyZP/6UKSFv2/sf391Cmz0hN0itUTH1rR4XeLln8XCOtarkrzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.577.0.tgz",
+      "integrity": "sha512-njmKSPDWueWWYVFpFcZ2P3fI6/pdQVDa0FgCyYZhOnJLgEHZIcBBg1AsnkVWacBuLopp9XVt2m+7hO6ugY1/1g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.577.0.tgz",
+      "integrity": "sha512-509Kklimva1XVlhGbpTpeX3kOP6ORpm44twJxDHpa9TURbmoaxj7veWlnLCbDorxDTrbsDghvYZshvcLsojVpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+      "version": "3.576.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.576.0.tgz",
+      "integrity": "sha512-KDvDlbeipSTIf+ffKtTg1m419TK7s9mZSWC8bvuZ9qx6/sjQFOXIKOVqyuli6DnfxGbvRcwoRuY99OcCH1N/0w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^2.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/signature-v4": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
+      "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.577.0.tgz",
+      "integrity": "sha512-n++yhCp67b9+ZRGEdY1jhamB5E/O+QsIDOPSuRmdaSGMCOd82oUEKPgIVEU1bkqxDsBxgiEWuvtfhK6sNiDS0A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.577.0.tgz",
+      "integrity": "sha512-q7lHPtv6BjRvChUE3m0tIaEZKxPTaZ1B3lKxGYsFl3VLAu5N8yGCUKwuA1izf4ucT+LyKscVGqK6VDZx1ev3nw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.577.0.tgz",
+      "integrity": "sha512-epZ1HOMsrXBNczc0HQpv0VMjqAEpc09DUA7Rg3gUJfn8umhML7A7bXnUyqPA+S54q397UYg1leQKdSn23OiwQQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.577.0",
+        "@aws-sdk/credential-provider-ini": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
+      "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.577.0.tgz",
+      "integrity": "sha512-iVm5SQvS7EgZTJsRaqUOmDQpBQPPPat42SCbWFvFQOLrl8qewq8OP94hFS5w2mP62zngeYzqhJnDel79HXbxew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.577.0",
+        "@aws-sdk/token-providers": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
+      "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
+      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
+      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
+      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
+      "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
+      "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
+      "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
+      "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
+      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
+      "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
+      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
+      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
+      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
+      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
+      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/url-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
+      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
+      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
+      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
+      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
+      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
+      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
+      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
@@ -6649,15 +8731,53 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.569.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.569.0.tgz",
-      "integrity": "sha512-CHS0Zyuazh5cYLaJr2/I9up0xAu8Y+um/h0o4xNf00cKGT0Sdhoby5vyelHjVTeZt+OeOMTBt6IdqGwVbVG9gQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.577.0.tgz",
+      "integrity": "sha512-y5yo4RKQSIQEOGLMLziLh0MZ+CxLs2QmTRjh8PkL8ovy12FPyou9Ptr7hIDD5SnCsiItJful5qbmj9e2QSmozw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.569.0",
-        "@aws-sdk/types": "3.567.0",
-        "@smithy/property-provider": "^2.2.0",
-        "@smithy/types": "^2.12.0",
+        "@aws-sdk/client-cognito-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6827,30 +8947,1064 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.569.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.569.0.tgz",
-      "integrity": "sha512-UL7EewaM1Xk6e4XLsxrCBv/owVSDI6Katnok6uMfqA8dA0x3ELjO7W35DW4wpWejQHErN5Gp1zloV9y3t34FMQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.577.0.tgz",
+      "integrity": "sha512-/fzdyyAetJxTPH8f2bh1UkcN48dScLb6LjBj9+wX2BHyKSZUal7+TqPTyme4f3pj1I1EeKhDIYKldR8YyMPIAg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.569.0",
-        "@aws-sdk/client-sso": "3.568.0",
-        "@aws-sdk/client-sts": "3.569.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.569.0",
-        "@aws-sdk/credential-provider-env": "3.568.0",
-        "@aws-sdk/credential-provider-http": "3.568.0",
-        "@aws-sdk/credential-provider-ini": "3.568.0",
-        "@aws-sdk/credential-provider-node": "3.569.0",
-        "@aws-sdk/credential-provider-process": "3.568.0",
-        "@aws-sdk/credential-provider-sso": "3.568.0",
-        "@aws-sdk/credential-provider-web-identity": "3.568.0",
-        "@aws-sdk/types": "3.567.0",
-        "@smithy/credential-provider-imds": "^2.3.0",
-        "@smithy/property-provider": "^2.2.0",
-        "@smithy/types": "^2.12.0",
+        "@aws-sdk/client-cognito-identity": "3.577.0",
+        "@aws-sdk/client-sso": "3.577.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.577.0",
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.577.0",
+        "@aws-sdk/credential-provider-ini": "3.577.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.577.0.tgz",
+      "integrity": "sha512-BwujdXrydlk6UEyPmewm5GqG4nkQ6OVyRhS/SyZP/6UKSFv2/sf391Cmz0hN0itUTH1rR4XeLln8XCOtarkrzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.577.0.tgz",
+      "integrity": "sha512-njmKSPDWueWWYVFpFcZ2P3fI6/pdQVDa0FgCyYZhOnJLgEHZIcBBg1AsnkVWacBuLopp9XVt2m+7hO6ugY1/1g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.577.0.tgz",
+      "integrity": "sha512-509Kklimva1XVlhGbpTpeX3kOP6ORpm44twJxDHpa9TURbmoaxj7veWlnLCbDorxDTrbsDghvYZshvcLsojVpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.577.0",
+        "@aws-sdk/core": "3.576.0",
+        "@aws-sdk/credential-provider-node": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.0",
+        "@smithy/util-defaults-mode-node": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+      "version": "3.576.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.576.0.tgz",
+      "integrity": "sha512-KDvDlbeipSTIf+ffKtTg1m419TK7s9mZSWC8bvuZ9qx6/sjQFOXIKOVqyuli6DnfxGbvRcwoRuY99OcCH1N/0w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^2.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/signature-v4": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
+      "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.577.0.tgz",
+      "integrity": "sha512-n++yhCp67b9+ZRGEdY1jhamB5E/O+QsIDOPSuRmdaSGMCOd82oUEKPgIVEU1bkqxDsBxgiEWuvtfhK6sNiDS0A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/fetch-http-handler": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.577.0.tgz",
+      "integrity": "sha512-q7lHPtv6BjRvChUE3m0tIaEZKxPTaZ1B3lKxGYsFl3VLAu5N8yGCUKwuA1izf4ucT+LyKscVGqK6VDZx1ev3nw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.577.0.tgz",
+      "integrity": "sha512-epZ1HOMsrXBNczc0HQpv0VMjqAEpc09DUA7Rg3gUJfn8umhML7A7bXnUyqPA+S54q397UYg1leQKdSn23OiwQQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.577.0",
+        "@aws-sdk/credential-provider-ini": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.577.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
+      "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.577.0.tgz",
+      "integrity": "sha512-iVm5SQvS7EgZTJsRaqUOmDQpBQPPPat42SCbWFvFQOLrl8qewq8OP94hFS5w2mP62zngeYzqhJnDel79HXbxew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.577.0",
+        "@aws-sdk/token-providers": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
+      "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
+      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
+      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
+      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
+      "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
+      "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
+      "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
+      "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
+      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
+      "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
+      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
+      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
+      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
+      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
+      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
+      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
+      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
+      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
+      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
+      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
+      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
+      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
@@ -10568,14 +13722,14 @@
       "dev": true
     },
     "node_modules/@next/env": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
-      "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
+      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
-      "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
+      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
       "cpu": [
         "arm64"
       ],
@@ -10588,9 +13742,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
-      "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
+      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
       "cpu": [
         "x64"
       ],
@@ -10603,9 +13757,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
-      "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
+      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
       "cpu": [
         "arm64"
       ],
@@ -10618,9 +13772,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
-      "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
+      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
       "cpu": [
         "arm64"
       ],
@@ -10633,9 +13787,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
-      "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
+      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
       "cpu": [
         "x64"
       ],
@@ -10648,9 +13802,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
-      "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
+      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
       "cpu": [
         "x64"
       ],
@@ -10663,9 +13817,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
-      "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
+      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
       "cpu": [
         "arm64"
       ],
@@ -10678,9 +13832,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
-      "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
+      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
       "cpu": [
         "ia32"
       ],
@@ -10693,9 +13847,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
-      "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
+      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
       "cpu": [
         "x64"
       ],
@@ -12056,11 +15210,17 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
       "dependencies": {
+        "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
     },
@@ -12085,9 +15245,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
-      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -12100,9 +15260,9 @@
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.2.tgz",
+      "integrity": "sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -12345,24 +15505,24 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.2.0.tgz",
-      "integrity": "sha512-mpQN+J5Dd1hC8lolPo1KuHST7mRwtNiEd821c9whgf46gr5gpkE+yP9ta4YUYzN+hv60n7c0cAbu/2e6nSLtOA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.3.2.tgz",
+      "integrity": "sha512-vjpw3UhC87wsqOzV3KlWLUf88ddRpJt1ZLdzAGKxTzftysFwCtEDnZ8/ICrfRVEvXvfex3q8qriPTWTnE6Ni6w==",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.29",
-        "@aws-amplify/api": "6.0.31",
-        "@aws-amplify/auth": "6.2.2",
-        "@aws-amplify/core": "6.1.0",
-        "@aws-amplify/datastore": "5.0.31",
-        "@aws-amplify/notifications": "2.0.29",
-        "@aws-amplify/storage": "6.4.0",
+        "@aws-amplify/analytics": "7.0.31",
+        "@aws-amplify/api": "6.0.33",
+        "@aws-amplify/auth": "6.3.2",
+        "@aws-amplify/core": "6.2.1",
+        "@aws-amplify/datastore": "5.0.33",
+        "@aws-amplify/notifications": "2.0.31",
+        "@aws-amplify/storage": "6.4.2",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.140.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.140.0.tgz",
-      "integrity": "sha512-5NzmXFqjGYiTFZ+jgWBQJvrjhMIlYMoNTOwgvzHj2YnP9LhEsr60IdRGiXYD9CZyR79Hr3VQNbjcgO35bvW9/w==",
+      "version": "2.142.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.142.1.tgz",
+      "integrity": "sha512-1ENZ2TY5/4uoPXat7vIzZIATdFGLy0UuqFeFU0AB/YFQqfTuSgsZRKYphpOi0zhcoDQ4rc8rPr/Dud+ZxXSc9Q==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -13418,9 +16578,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -14441,9 +17601,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
-      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -14459,21 +17619,21 @@
       "dev": true
     },
     "node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "version": "10.3.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
+      "integrity": "sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.6",
         "minimatch": "^9.0.1",
         "minipass": "^7.0.4",
-        "path-scurry": "^1.10.2"
+        "path-scurry": "^1.11.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -14490,11 +17650,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -15677,9 +18832,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
-      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
+      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -15790,43 +18945,47 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
-      "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
+      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
       "dependencies": {
-        "@next/env": "13.5.4",
-        "@swc/helpers": "0.5.2",
+        "@next/env": "14.2.3",
+        "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001406",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0"
+        "styled-jsx": "5.1.1"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.4",
-        "@next/swc-darwin-x64": "13.5.4",
-        "@next/swc-linux-arm64-gnu": "13.5.4",
-        "@next/swc-linux-arm64-musl": "13.5.4",
-        "@next/swc-linux-x64-gnu": "13.5.4",
-        "@next/swc-linux-x64-musl": "13.5.4",
-        "@next/swc-win32-arm64-msvc": "13.5.4",
-        "@next/swc-win32-ia32-msvc": "13.5.4",
-        "@next/swc-win32-x64-msvc": "13.5.4"
+        "@next/swc-darwin-arm64": "14.2.3",
+        "@next/swc-darwin-x64": "14.2.3",
+        "@next/swc-linux-arm64-gnu": "14.2.3",
+        "@next/swc-linux-arm64-musl": "14.2.3",
+        "@next/swc-linux-x64-gnu": "14.2.3",
+        "@next/swc-linux-x64-musl": "14.2.3",
+        "@next/swc-win32-arm64-msvc": "14.2.3",
+        "@next/swc-win32-ia32-msvc": "14.2.3",
+        "@next/swc-win32-x64-msvc": "14.2.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
           "optional": true
         },
         "sass": {
@@ -16203,15 +19362,15 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -17749,13 +20908,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsx": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.9.1.tgz",
-      "integrity": "sha512-CqSJaYyZ6GEqnGtPuMPQHvUwRGU6VHSVF+RDxoOmRg/XD4aF0pD973tKhoUYGQtdcoCHcSOGk34ioFaP+vYcMQ==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.10.4.tgz",
+      "integrity": "sha512-Gtg9qnZWNqC/OtcgiXfoAUdAKx3/cgKOYvEocAsv+m21MV/eKpV/WUjRXe6/sDCaGBl2/v8S6v29BpUnGMCX5A==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.20.2",
-        "get-tsconfig": "^4.7.3"
+        "get-tsconfig": "^4.7.5"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -18104,18 +21263,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^6.1.9",
-    "aws-amplify": "^6.2.0",
-    "next": "13.5.4",
-    "react": "^18",
-    "react-dom": "^18"
+    "@aws-amplify/ui-react": "^6.1.11",
+    "aws-amplify": "^6.3.2",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@aws-amplify/backend": "^1.0.0",
-    "@aws-amplify/backend-cli": "^1.0.1",
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "typescript": "^5.3.2"
+    "@aws-amplify/backend": "^1.0.2",
+    "@aws-amplify/backend-cli": "^1.0.3",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.2",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
No issue available, but during Discord Office Hours I spoke with the Amplify team, about the dependencies being out of date in this project, particularly Next.js being on a version which was [published 7 months ago](https://www.npmjs.com/package/next/v/13.5.4)

*Description of changes:*
Update all dependencies to the latest version on npm, as of May 17 2024.
After installing all versions in this PR, I ran the project locally to test that it works as expected. The project runs fine, I've attached a screenshot showing the project running with these updates.

<img width="1023" alt="Screenshot 2024-05-17 at 12 23 12" src="https://github.com/aws-samples/amplify-next-template/assets/34548660/29b6526e-7bbc-4329-95d4-e94879cddcd3">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
