### PR TITLE
fix: prebuild @parcel added

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,7 @@ backend:
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
+        - npm run prebuild
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "npm install @parcel/watcher",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
*Issue #, if available:*
Error during Amplify build: `Error(`No prebuild or local build of @parcel/watcher found. Tried ${name}. Please ensure it is installed (don't use --no-optional when installing with npm)`

@parcel/watcher needs a prebuild step, possibly due to the use of `--no-optional`. 

*Description of changes:*
Added a `prebuild` execution for installing @parcel/watcher. Added to package.json to ensure the packages are correctly updated. Execution of `prebuild` within `amplify.yml` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
